### PR TITLE
Task 5.11: add LeaderBoard page

### DIFF
--- a/packages/client/src/app/router/routes.tsx
+++ b/packages/client/src/app/router/routes.tsx
@@ -9,6 +9,7 @@ import { ForumPage } from '@/pages/forum';
 import { LayoutWithTopbar } from '@/pages/layout-with-topbar';
 import { ForumTopicViewPage } from '@/pages/forum-topic-view';
 import { ForumTopicEditPage, topicLoader } from '@/pages/forum-topic-edit';
+import { LeaderBoard } from '@/pages/lider-board';
 
 export const router = createBrowserRouter([
   {
@@ -63,11 +64,12 @@ export const router = createBrowserRouter([
       {
         path: '/game',
         element: <GamePage />
+      },
+      {
+        path: '/leaderboard',
+        lazy: LayoutWithTopbar,
+        children: [{ index: true, lazy: LeaderBoard }]
       }
-      // {
-      //   path: '/leaderboard',
-      //   element: <SignUpPage />
-      // },
       // {
       //   path: '/forum',
       //   element: <SignUpPage />

--- a/packages/client/src/app/styles/variables.scss
+++ b/packages/client/src/app/styles/variables.scss
@@ -12,6 +12,9 @@
   --color-onion: #373710;
   --color-charcoal-sand: #2e2e0e;
   --color-mossy-gray: #484836;
+  --color-gold-text: #ffd700;
+  --color-silver-text: #c0c0c0;
+  --color-bronze-text: #cd7f32;
 
   // shadows
   --shadow-yellow-text: 1px 1px 10px var(--color-yellow-text-opacity90);

--- a/packages/client/src/pages/lider-board/api/getPlayerList.ts
+++ b/packages/client/src/pages/lider-board/api/getPlayerList.ts
@@ -1,0 +1,16 @@
+// TODO: add real api
+
+import { DEFAULT_PLAYERS_ON_SCREEN } from '../constants';
+import { PlayerListRequestDto, PlayerListResponseDto } from '../model/types';
+import { mockPlayerList } from './mockData';
+
+export const getPlayerList = async (page: number): Promise<PlayerListResponseDto> => {
+  const skip: number = (page - 1) * DEFAULT_PLAYERS_ON_SCREEN;
+  const data: PlayerListRequestDto = { skip, limit: DEFAULT_PLAYERS_ON_SCREEN };
+
+  console.log('Loading players...', data);
+
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  return mockPlayerList;
+};

--- a/packages/client/src/pages/lider-board/api/mockData.ts
+++ b/packages/client/src/pages/lider-board/api/mockData.ts
@@ -1,0 +1,13 @@
+import { DEFAULT_PLAYERS_ON_SCREEN } from '../constants';
+import { PlayerListResponseDto } from '../model/types';
+
+export const mockPlayerList: PlayerListResponseDto = {
+  players: Array.from({ length: DEFAULT_PLAYERS_ON_SCREEN }, (_, index) => ({
+    id: index + 1,
+    login: `Mock login ${index + 1}`,
+    achievement: 1000 - index * 23,
+    wins: (20 - index * 2) / 2,
+    games: 30 - index * 2
+  })),
+  total: 27
+};

--- a/packages/client/src/pages/lider-board/constants.ts
+++ b/packages/client/src/pages/lider-board/constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_PLAYERS_ON_SCREEN = 10;

--- a/packages/client/src/pages/lider-board/hooks/usePlayerList.ts
+++ b/packages/client/src/pages/lider-board/hooks/usePlayerList.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { PlayerPreview } from '../model/types';
+import { getPlayerList } from '../api/getPlayerList';
+
+export const usePlayerList = (page: number) => {
+  const [players, setPlayers] = useState<PlayerPreview[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [total, setTotal] = useState<number>(0);
+
+  useEffect(() => {
+    let isLive = true;
+
+    setIsLoading(true);
+
+    getPlayerList(page).then(({ players, total }) => {
+      if (isLive) {
+        setPlayers(players);
+        setTotal(total);
+        setIsLoading(false);
+      }
+    });
+
+    return () => {
+      isLive = false;
+    };
+  }, [page]);
+
+  return {
+    players,
+    isLoading,
+    total
+  };
+};

--- a/packages/client/src/pages/lider-board/index.ts
+++ b/packages/client/src/pages/lider-board/index.ts
@@ -1,0 +1,1 @@
+export { LeaderBoardPageAsync as LeaderBoard } from './ui/LeaderBoardPage.async';

--- a/packages/client/src/pages/lider-board/model/types.ts
+++ b/packages/client/src/pages/lider-board/model/types.ts
@@ -1,0 +1,19 @@
+import { User, UserId } from '@/entities/user';
+
+export type PlayerPreview = {
+  id: UserId;
+  login: User['login'];
+  achievement: number;
+  wins: number;
+  games: number;
+};
+
+export type PlayerListResponseDto = {
+  players: PlayerPreview[];
+  total: number;
+};
+
+export type PlayerListRequestDto = {
+  skip: number;
+  limit: number;
+};

--- a/packages/client/src/pages/lider-board/ui/LeaderBoardPage.async.tsx
+++ b/packages/client/src/pages/lider-board/ui/LeaderBoardPage.async.tsx
@@ -1,0 +1,1 @@
+export const LeaderBoardPageAsync = async () => ({ Component: (await import('./LeaderBoardPage')).LeaderBoardPage });

--- a/packages/client/src/pages/lider-board/ui/LeaderBoardPage.module.scss
+++ b/packages/client/src/pages/lider-board/ui/LeaderBoardPage.module.scss
@@ -1,0 +1,16 @@
+.title {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+
+  span {
+    font-size: 2rem;
+    align-self: end;
+    line-height: 2rem;
+  }
+
+  .flipHorizontal {
+    transform: scaleX(-1);
+  }
+}

--- a/packages/client/src/pages/lider-board/ui/LeaderBoardPage.tsx
+++ b/packages/client/src/pages/lider-board/ui/LeaderBoardPage.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { Card } from 'react-bootstrap';
+import { GiTrophyCup } from 'react-icons/gi';
+import { GiLibertyWing } from 'react-icons/gi';
+
+import { Breadcrumbs, Pagination, Spinner } from '@/shared/ui';
+import { ForumLayout } from '@/widgets/forum-layout';
+import { usePlayerList } from '../hooks/usePlayerList';
+import { DEFAULT_PAGE, DEFAULT_PLAYERS_ON_SCREEN } from '../constants';
+import { PlayersTable } from './PlayersTable/PlayersTable';
+
+import styles from './LeaderBoardPage.module.scss';
+
+export const LeaderBoardPage = () => {
+  const [page, setPage] = useState(DEFAULT_PAGE);
+  const { players, isLoading, total } = usePlayerList(page);
+
+  return (
+    <ForumLayout
+      top={
+        <>
+          <Breadcrumbs
+            links={[
+              { label: 'Главная', to: '/' },
+              { label: 'Таблица лидеров', to: '/leaderboard' }
+            ]}
+          />
+        </>
+      }>
+      <Card>
+        <Card.Header>
+          <Card.Title className={styles.title}>
+            <GiTrophyCup size={64} />
+            <GiLibertyWing
+              size={64}
+              className={styles.flipHorizontal}
+            />
+
+            <span> LeaderBoard </span>
+
+            <GiLibertyWing size={64} />
+            <GiTrophyCup size={64} />
+          </Card.Title>
+        </Card.Header>
+
+        <Card.Body>{isLoading ? <Spinner /> : <PlayersTable players={players} />}</Card.Body>
+
+        <Card.Footer>
+          <Pagination
+            page={page}
+            total={total}
+            limit={DEFAULT_PLAYERS_ON_SCREEN}
+            onNextClick={() => setPage((prev) => prev + 1)}
+            onPrevClick={() => setPage((prev) => prev - 1)}
+          />
+        </Card.Footer>
+      </Card>
+    </ForumLayout>
+  );
+};

--- a/packages/client/src/pages/lider-board/ui/PlayerRow/PlayerRow.module.scss
+++ b/packages/client/src/pages/lider-board/ui/PlayerRow/PlayerRow.module.scss
@@ -1,0 +1,38 @@
+@use 'styles/typography';
+
+.row {
+  td {
+    @include typography.font(p3);
+
+    padding: 0.75rem 1rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    background-color: var(--color-mossy-gray);
+    color: var(--color-white-text);
+    vertical-align: middle;
+  }
+
+  .position {
+    position: relative;
+
+    svg {
+      position: absolute;
+      left: 2rem;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+
+    .first {
+      color: var(--color-gold-text);
+    }
+
+    .second {
+      color: var(--color-silver-text);
+    }
+
+    .third {
+      color: var(--color-bronze-text);
+    }
+  }
+}

--- a/packages/client/src/pages/lider-board/ui/PlayerRow/PlayerRow.module.scss
+++ b/packages/client/src/pages/lider-board/ui/PlayerRow/PlayerRow.module.scss
@@ -35,4 +35,16 @@
       color: var(--color-bronze-text);
     }
   }
+
+  .achievement {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    justify-content: center;
+    line-height: 1rem;
+
+    svg {
+      color: var(--color-yellow-text);
+    }
+  }
 }

--- a/packages/client/src/pages/lider-board/ui/PlayerRow/PlayerRow.tsx
+++ b/packages/client/src/pages/lider-board/ui/PlayerRow/PlayerRow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { GiTrophyCup } from 'react-icons/gi';
+import { GrFireball } from 'react-icons/gr';
 
 import { PlayerPreview } from '../../model/types';
 
@@ -42,13 +43,12 @@ export const PlayerRow = ({ player: { id, login, achievement, wins, games }, pos
         {position}
       </td>
       <td>
-        <Link
-          className={styles.login}
-          to={playerProfileUrl}>
-          {login}
-        </Link>
+        <Link to={playerProfileUrl}>{login}</Link>
       </td>
-      <td>{achievement}</td>
+      <td className={styles.achievement}>
+        <GrFireball size={12} />
+        {achievement}
+      </td>
       <td>{games}</td>
       <td>{wins}</td>
     </tr>

--- a/packages/client/src/pages/lider-board/ui/PlayerRow/PlayerRow.tsx
+++ b/packages/client/src/pages/lider-board/ui/PlayerRow/PlayerRow.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { GiTrophyCup } from 'react-icons/gi';
+
+import { PlayerPreview } from '../../model/types';
+
+import styles from './PlayerRow.module.scss';
+
+type Props = {
+  player: PlayerPreview;
+  position: number;
+};
+
+const cups: Record<number, React.ReactElement | undefined> = {
+  1: (
+    <GiTrophyCup
+      size={16}
+      className={styles.first}
+    />
+  ),
+  2: (
+    <GiTrophyCup
+      size={16}
+      className={styles.second}
+    />
+  ),
+  3: (
+    <GiTrophyCup
+      size={16}
+      className={styles.third}
+    />
+  )
+};
+
+export const PlayerRow = ({ player: { id, login, achievement, wins, games }, position }: Props) => {
+  const playerProfileUrl = `/profile/${id}`;
+
+  return (
+    <tr className={styles.row}>
+      <td className={styles.position}>
+        {cups[position]}
+        {position}
+      </td>
+      <td>
+        <Link
+          className={styles.login}
+          to={playerProfileUrl}>
+          {login}
+        </Link>
+      </td>
+      <td>{achievement}</td>
+      <td>{games}</td>
+      <td>{wins}</td>
+    </tr>
+  );
+};

--- a/packages/client/src/pages/lider-board/ui/PlayersTable/PlayersTable.module.scss
+++ b/packages/client/src/pages/lider-board/ui/PlayersTable/PlayersTable.module.scss
@@ -1,0 +1,32 @@
+@use 'styles/typography';
+
+.table {
+  margin: 0;
+  table-layout: fixed;
+  text-align: center;
+
+  tr {
+    border-color: var(--color-yellow-opacity50);
+  }
+
+  th {
+    @include typography.font(p2);
+
+    padding: 1rem;
+    background-color: var(--color-onion);
+    color: var(--color-yellow-text);
+    vertical-align: middle;
+
+    &:first-child {
+      padding: 0;
+      width: 160px;
+    }
+  }
+}
+
+.noData {
+  @include typography.font(p2);
+
+  padding: 100px 0;
+  text-align: center;
+}

--- a/packages/client/src/pages/lider-board/ui/PlayersTable/PlayersTable.tsx
+++ b/packages/client/src/pages/lider-board/ui/PlayersTable/PlayersTable.tsx
@@ -1,0 +1,39 @@
+import { Table } from 'react-bootstrap';
+
+import { PlayerPreview } from '../../model/types';
+import { PlayerRow } from '../PlayerRow/PlayerRow';
+
+import styles from './PlayersTable.module.scss';
+
+type Props = {
+  players: PlayerPreview[];
+};
+
+export const PlayersTable = ({ players }: Props) => {
+  const playersList = players.map((player, index) => (
+    <PlayerRow
+      key={player.id}
+      position={index + 1}
+      player={player}
+    />
+  ));
+
+  if (!playersList.length) return <div className={styles.noData}>Список игроков пуст</div>;
+
+  return (
+    <Table
+      hover
+      className={styles.table}>
+      <thead>
+        <tr>
+          <th>Позиция</th>
+          <th>Логин</th>
+          <th>Очки</th>
+          <th>Проведено игр</th>
+          <th>Одержано побед</th>
+        </tr>
+      </thead>
+      <tbody>{playersList}</tbody>
+    </Table>
+  );
+};


### PR DESCRIPTION
### Какую задачу решаем
Добавить роут для лидерборда.
Сверстать страницу лидерборда.
Добавлен роут для лидерборда, при переходе авторизованного пользователя на этот экран отображается список моковых рекордов.

Лидерборд представляет собой список рекордов пользователей вашей игры.

### Скриншоты/видяшка (если есть)
![image](https://github.com/user-attachments/assets/e40b8cdc-0fdc-4372-89fb-636628ea0fc7)

### TBD (если есть)